### PR TITLE
Setting git version from current source directory

### DIFF
--- a/cmake/modules/GetGitRevisionDescription.cmake
+++ b/cmake/modules/GetGitRevisionDescription.cmake
@@ -110,7 +110,7 @@ function(git_describe _var)
 
 		${ARGN}
 		WORKING_DIRECTORY
-		"${CMAKE_SOURCE_DIR}"
+        "${CMAKE_CURRENT_SOURCE_DIR}"
 		RESULT_VARIABLE
 		res
 		OUTPUT_VARIABLE


### PR DESCRIPTION
Given a project A that uses version_git, and a project B that uses version_git, this change allows B to pull in A via FetchContent(), but have A's individual version maintained.